### PR TITLE
stop validating and converting default values

### DIFF
--- a/lib/open_feature/flagsmith/provider.rb
+++ b/lib/open_feature/flagsmith/provider.rb
@@ -102,7 +102,7 @@ module OpenFeature
       # @see https://github.com/open-feature/ruby-sdk/tree/main?tab=readme-ov-file#develop-a-provider
       #
       # @param flag_key [String, Symbol] The key of the flag to fetch.
-      # @param default_value [Integer, #to_i, #to_int, nil] The default value to return if the flag is not found.
+      # @param default_value [Integer, nil] The default value to return if the flag is not found.
       # @param evaluation_context [SDK::Provider::EvaluationContext] An object that provides context for flag evaluation.
       # @return [SDK::Provider::ResolutionDetails]
       def fetch_integer_value(flag_key:, default_value:, evaluation_context: nil)
@@ -114,7 +114,7 @@ module OpenFeature
       # @see https://github.com/open-feature/ruby-sdk/tree/main?tab=readme-ov-file#develop-a-provider
       #
       # @param flag_key [String, Symbol] The key of the flag to fetch.
-      # @param default_value [Float, #to_f, nil] The default value to return if the flag is not found.
+      # @param default_value [Float, nil] The default value to return if the flag is not found.
       # @param evaluation_context [SDK::Provider::EvaluationContext] An object that provides context for flag evaluation.
       # @return [SDK::Provider::ResolutionDetails]
       def fetch_float_value(flag_key:, default_value:, evaluation_context: nil)
@@ -133,7 +133,7 @@ module OpenFeature
       #   it with {#fetch_string_value}, and then parse it in your application.
       #
       # @param flag_key [String, Symbol] The key of the flag to fetch.
-      # @param default_value [Object] The default value to return if the flag is not found.
+      # @param default_value [Object, nil] The default value to return if the flag is not found.
       # @param evaluation_context [SDK::Provider::EvaluationContext] An object that provides context for flag evaluation.
       # @return [SDK::Provider::ResolutionDetails]
       def fetch_object_value(flag_key:, default_value:, evaluation_context: nil) # rubocop:disable Lint/UnusedMethodArgument

--- a/lib/open_feature/flagsmith/provider/boolean_resolver.rb
+++ b/lib/open_feature/flagsmith/provider/boolean_resolver.rb
@@ -8,14 +8,6 @@ module OpenFeature
     class Provider
       # @api private
       class BooleanResolver < Resolver
-        def resolve(flag_key:, default_value:, evaluation_context:)
-          unless default_value.nil? || [true, false].include?(default_value)
-            raise TypeMismatchError, "Default value must be true, false, or nil"
-          end
-
-          super
-        end
-
         def process(flag)
           flag.enabled?
         end

--- a/lib/open_feature/flagsmith/provider/float_resolver.rb
+++ b/lib/open_feature/flagsmith/provider/float_resolver.rb
@@ -8,14 +8,6 @@ module OpenFeature
     class Provider
       # @api private
       class FloatResolver < Resolver
-        def resolve(flag_key:, default_value:, evaluation_context:)
-          unless default_value.nil? || default_value.is_a?(Float) || default_value.respond_to?(:to_f)
-            raise TypeError, "Default value must be a float, convertible to a float, or nil"
-          end
-
-          super
-        end
-
         def process_value(value)
           return value if value.is_a?(Float)
           return value.to_f if value.respond_to?(:to_f)

--- a/lib/open_feature/flagsmith/provider/integer_resolver.rb
+++ b/lib/open_feature/flagsmith/provider/integer_resolver.rb
@@ -12,14 +12,6 @@ module OpenFeature
       #
       # @api private
       class IntegerResolver < Resolver
-        def resolve(flag_key:, default_value:, evaluation_context:)
-          unless default_value.nil? || default_value.is_a?(Integer) || default_value.respond_to?(:to_i)
-            raise TypeError, "Default value must be an integer, convertible to an integer, or nil"
-          end
-
-          super
-        end
-
         def process_value(value)
           return value if value.is_a?(Integer)
           return value.to_i if value.respond_to?(:to_i)

--- a/lib/open_feature/flagsmith/provider/number_resolver.rb
+++ b/lib/open_feature/flagsmith/provider/number_resolver.rb
@@ -8,14 +8,6 @@ module OpenFeature
     class Provider
       # @api private
       class NumberResolver < Resolver
-        def resolve(flag_key:, default_value:, evaluation_context:)
-          unless default_value.nil? || default_value.is_a?(Numeric)
-            raise TypeMismatchError, "Default value must be a number or nil"
-          end
-
-          super
-        end
-
         def process_value(value)
           raise TypeMismatchError, "Flag value is not numeric" unless value.is_a?(Numeric)
 

--- a/lib/open_feature/flagsmith/provider/resolver.rb
+++ b/lib/open_feature/flagsmith/provider/resolver.rb
@@ -30,7 +30,7 @@ module OpenFeature
           result = process(flag)
           FlagResolutionCreator.call(flag_key:, flag:, value: result)
         rescue StandardError => e
-          ErrorResolutionCreator.call(flag_key:, value: process_value(default_value), error_mapping:, error: e)
+          ErrorResolutionCreator.call(flag_key:, value: default_value, error_mapping:, error: e)
         end
 
         # Process the value returned by the Flagsmith client.

--- a/lib/open_feature/flagsmith/provider/string_resolver.rb
+++ b/lib/open_feature/flagsmith/provider/string_resolver.rb
@@ -8,14 +8,6 @@ module OpenFeature
     class Provider
       # @api private
       class StringResolver < Resolver
-        def resolve(flag_key:, default_value:, evaluation_context:)
-          unless default_value.nil? || default_value.is_a?(String)
-            raise TypeMismatchError, "Default value must be a string or nil"
-          end
-
-          super
-        end
-
         def process_value(value)
           # Note that we do not try to call `#to_s` on the value, because
           # every value in Ruby responds to `#to_s`, so it would be too easy


### PR DESCRIPTION
This commit removes any validations for default values, as well as any attempts to process default values.

This better matches the behavior of other providers, including the in memory provider that comes with the OpenFeature SDK itself.

See: https://github.com/open-feature/ruby-sdk/blob/3ca368d40cf071d16f829d46919b871099401714/lib/open_feature/sdk/provider/in_memory_provider.rb