### PR TITLE
fix boolean handling

### DIFF
--- a/lib/open_feature/flagsmith/provider/resolver.rb
+++ b/lib/open_feature/flagsmith/provider/resolver.rb
@@ -35,7 +35,8 @@ module OpenFeature
         # @param evaluation_context [SDK::Provider::EvaluationContext]
         #   An object that provides context for flag evaluation.
         #
-        # @yield [flag_value] Gives the flag value to the block, if the flag is found AND enabled.
+        # @yield [flag, flag_value] Gives the flag value to the block, if the flag is found AND enabled.
+        # @yieldparam flag [::Flagsmith::Flags::Flag] The flag itself
         # @yieldparam flag_value [Object] The value of the flag
         # @yieldreturn [Object] The processed value of the flag
         #
@@ -67,7 +68,7 @@ module OpenFeature
           # from the API or local evaluation. In this case, we want to process
           # the returned value using the given block, so that we can be sure
           # the found flag has the correct type.
-          live_value_resolution_details(flag:, processed_value: yield(flag.value))
+          live_value_resolution_details(flag:, processed_value: yield(flag, flag.value))
         rescue StandardError => e
           # Capute any errors that occur during either flag fetching or value
           # processing, so that this method is guaranteed to always return an

--- a/lib/open_feature/flagsmith/provider/value_processors/boolean.rb
+++ b/lib/open_feature/flagsmith/provider/value_processors/boolean.rb
@@ -4,7 +4,31 @@ module OpenFeature
   module Flagsmith
     class Provider
       module ValueProcessors
-        Boolean = lambda do |value|
+        Boolean = lambda do |flag, value|
+          # When a flag is first created, Flagsmith sets the value to nil, and
+          # as long as the value is never changed through the UI, the value will
+          # stay as nil. In this case, the flag's enabled status should be used
+          # as the value of the flag.
+          #
+          # Note that in practice this particular code path SHOULD always return
+          # `true`, because the resolver bails out early and uses a default
+          # value if the flag is disabled. However, for the sake of correctness,
+          # we should still explicitly check the flag's enabled status here.
+          return flag.enabled? if value.nil?
+
+          # Similarly, if a flag ever had a value, but it's then cleared, the
+          # value of the flag will still be a string. When this happens, we want
+          # to defer to the flag's enabled state, but only if the value is a
+          # blank string, i.e. empty or whitespace-only. If the flag has any
+          # non-whitespace characters, we should treat it as an invalid boolean
+          # flag and end up raising an error.
+          #
+          # As with the nil case above, this check should only be reached if
+          # the flag itself is enabled.
+          return true if value.is_a?(::String) && value.strip.empty?
+
+          # Otherwise, look at the flag value itself.
+          #
           # We're leaving some performance on the table here by using an inline
           # array rather than using multiple comparisons or extracting the array
           # to a constant. In practice, this shouldn't matter too much for

--- a/lib/open_feature/flagsmith/provider/value_processors/float.rb
+++ b/lib/open_feature/flagsmith/provider/value_processors/float.rb
@@ -4,7 +4,7 @@ module OpenFeature
   module Flagsmith
     class Provider
       module ValueProcessors
-        Float = lambda do |value|
+        Float = lambda do |_flag, value|
           return value if value.is_a?(::Float)
           return value.to_f if value.is_a?(Numeric) && value.respond_to?(:to_f)
 

--- a/lib/open_feature/flagsmith/provider/value_processors/integer.rb
+++ b/lib/open_feature/flagsmith/provider/value_processors/integer.rb
@@ -4,7 +4,7 @@ module OpenFeature
   module Flagsmith
     class Provider
       module ValueProcessors
-        Integer = lambda do |value|
+        Integer = lambda do |_flag, value|
           return value if value.is_a?(::Integer)
           return value.to_int if value.respond_to?(:to_int)
 

--- a/lib/open_feature/flagsmith/provider/value_processors/number.rb
+++ b/lib/open_feature/flagsmith/provider/value_processors/number.rb
@@ -4,7 +4,7 @@ module OpenFeature
   module Flagsmith
     class Provider
       module ValueProcessors
-        Number = lambda do |value|
+        Number = lambda do |_flag, value|
           return value if value.is_a?(Numeric)
 
           raise TypeMismatchError, "Flag value is not a number"

--- a/lib/open_feature/flagsmith/provider/value_processors/object.rb
+++ b/lib/open_feature/flagsmith/provider/value_processors/object.rb
@@ -9,7 +9,7 @@ module OpenFeature
   module Flagsmith
     class Provider
       module ValueProcessors
-        Object = lambda do |value|
+        Object = lambda do |_flag, value|
           JSON.parse(value)
         rescue JSON::ParserError => e
           raise ParseError, "Flag value cannot be parsed as JSON: #{e.message}"

--- a/lib/open_feature/flagsmith/provider/value_processors/string.rb
+++ b/lib/open_feature/flagsmith/provider/value_processors/string.rb
@@ -7,7 +7,7 @@ module OpenFeature
   module Flagsmith
     class Provider
       module ValueProcessors
-        String = lambda do |value|
+        String = lambda do |_flag, value|
           return value if value.is_a?(::String)
           return value.to_str if value.respond_to?(:to_str)
 


### PR DESCRIPTION
This commit updates the boolean handling in two ways:

- it uses the flag's enabled status as the source of truth if the value is nil
- it treats a blank string as true

These changes are to accomodate quirks of setting flag values in the Flagsmith web UI.