### PR TITLE
Force Identifier to Flagsmith to be a String

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     open_feature-flagsmith-provider (0.1.0)
-      flagsmith (~> 4.1.1)
+      flagsmith (~> 4.3)
       openfeature-sdk (~> 0.4.0)
 
 GEM
@@ -17,7 +17,7 @@ GEM
       net-http
     faraday-retry (2.2.1)
       faraday (~> 2.0)
-    flagsmith (4.1.1)
+    flagsmith (4.3.0)
       faraday (>= 2.0.1)
       faraday-retry
       semantic

--- a/lib/open_feature/flagsmith/provider/identity.rb
+++ b/lib/open_feature/flagsmith/provider/identity.rb
@@ -62,7 +62,7 @@ module OpenFeature
         attr_reader :traits
 
         def initialize(identifier:, transient:, traits:)
-          @identifier = identifier
+          @identifier = identifier.to_s # Flagsmith expects a string
           @transient = transient
           @traits = traits
         end

--- a/open_feature-flagsmith-provider.gemspec
+++ b/open_feature-flagsmith-provider.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
     end
   end
 
-  spec.add_dependency "flagsmith", "~> 4.1.1"
+  spec.add_dependency "flagsmith", "~> 4.3"
   spec.add_dependency "openfeature-sdk", "~> 0.4.0"
 
   spec.add_development_dependency "minitest", "~> 5.16"


### PR DESCRIPTION
Turns out that Flagsmith only accepts a String identifier for targeting. If you accidentally pass in a Hash, Int, or other identifier into this OpenFeature client, it'll fail when trying to get Identity Flags.